### PR TITLE
スマートフォン向けのレイアウトを修正 (Issue #2)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -18,12 +18,21 @@
         .md-table .md-table-cell .md-table-cell-container {
           /*background-color: #f00;*/
           padding: 6px 6px 6px 6px !important;
+          height: 48px;
         }
         /* 長い授業名は省略する */
         .md-table-cell-container > div {
           text-overflow: ellipsis;
           overflow: hidden;
           white-space: nowrap;
+          display: none;
+        }
+        /* 表示は2行まで */
+        .md-table-cell-container :first-child {
+          display: block;
+        }
+        .md-table-cell-container :nth-child(2) {
+          display: block;
         }
       }
     </style>

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,24 @@
       gtag('js', new Date());
       gtag('config', 'UA-57390908-2');
     </script>
+    <style>
+      @media (max-width: 900px) {
+        /* 広すぎる余白を狭く */
+        .md-table .md-table-head-text {
+          padding: 6px 6px 6px 6px !important;
+        }
+        .md-table .md-table-cell .md-table-cell-container {
+          /*background-color: #f00;*/
+          padding: 6px 6px 6px 6px !important;
+        }
+        /* 長い授業名は省略する */
+        .md-table-cell-container > div {
+          text-overflow: ellipsis;
+          overflow: hidden;
+          white-space: nowrap;
+        }
+      }
+    </style>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>シラバス検索</title>

--- a/src/pages/search.vue
+++ b/src/pages/search.vue
@@ -212,7 +212,7 @@ export default {
           }
 
           &:not(.only-large) {
-            width: 30%;
+            width: 15%;
           }
 
           &.title-column {


### PR DESCRIPTION
スマートフォン向けレイアウト(max-width: 900px)において、以下の変更を行った。
- 広すぎる余白を調節した
- 改行されるほど長い授業名は省略されるようにした
- 担当教官が多すぎるときは、代表2名のみ表示するようにした

本当はスタイルファイルを編集したかったが構成がわからなかったため、とりあえずインラインスタイルで解決した。ファイル構成を理解したら、美しく書き直したい。